### PR TITLE
Fix incompatibility with `nova-flexible-content`

### DIFF
--- a/src/FileManager.php
+++ b/src/FileManager.php
@@ -146,7 +146,7 @@ class FileManager extends Field
         $manager = FileManagerService::make();
 
         if (isset($this->diskColumn)) {
-            $disk = $resource->{$this->diskColumn};
+            $disk = parent::resolveAttribute($resource, $this->diskColumn);
         }
 
         if (isset($disk)) {

--- a/src/FileManager.php
+++ b/src/FileManager.php
@@ -6,7 +6,6 @@ namespace BBSLab\NovaFileManager;
 
 use BBSLab\NovaFileManager\Services\FileManagerService;
 use Closure;
-use Illuminate\Database\Eloquent\Model;
 use JsonException;
 use Laravel\Nova\Fields\Field;
 use Laravel\Nova\Fields\PresentsImages;
@@ -101,7 +100,7 @@ class FileManager extends Field
     {
         $this->storageCallback = $storageCallback ?? function (
             NovaRequest $request,
-            Model $model,
+            $model,
             string $attribute,
             string $requestAttribute
         ) {


### PR DESCRIPTION
Hi, [flexible-content](https://github.com/whitecube/nova-flexible-content/blob/master/src/Layouts/Layout.php) mocks the `Model` with a `Layout` which causes this package to throw an error while saving