### PR TITLE
Support filesystem as string

### DIFF
--- a/src/Contracts/Support/InteractsWithFilesystem.php
+++ b/src/Contracts/Support/InteractsWithFilesystem.php
@@ -17,7 +17,7 @@ interface InteractsWithFilesystem
 
     public function hasCustomFilesystem(): bool;
 
-    public function resolveFilesystem(NovaRequest $request): ?Filesystem;
+    public function resolveFilesystem(NovaRequest $request): Filesystem|string|null;
 
     public function showCreateFolder(Closure $callback): static;
 

--- a/src/Traits/Support/InteractsWithFilesystem.php
+++ b/src/Traits/Support/InteractsWithFilesystem.php
@@ -50,7 +50,7 @@ trait InteractsWithFilesystem
         return $this->filesystemCallback !== null && is_callable($this->filesystemCallback);
     }
 
-    public function resolveFilesystem(NovaRequest $request): ?Filesystem
+    public function resolveFilesystem(NovaRequest $request): Filesystem|string|null
     {
         return $this->hasCustomFilesystem()
             ? call_user_func($this->filesystemCallback, $request)


### PR DESCRIPTION
Hi, when forcing the field to use a specific disk, the disk stored to the DB is set to `default` 


```php
FileManager::make('File', 'file')->filesystem(fn() => Storage::disk('s3-private'))
```

```json
{
    "disk": "default",
    "path": "0RlUdoMViPSaAhQaesByCna1k1jIc1HRgoUQuinu.jpg"
}
```

With this change you are then able to return the disk name instead:

```php
FileManager::make('File', 'file')->filesystem(fn() => 's3-private')
```

```json
{
    "disk": "s3-private",
    "path": "0RlUdoMViPSaAhQaesByCna1k1jIc1HRgoUQuinu.jpg"
}
```